### PR TITLE
feat: adjust modal closing animation time

### DIFF
--- a/src/components/modal/Modal.css
+++ b/src/components/modal/Modal.css
@@ -26,7 +26,7 @@
 
     &.beforeClose {
         opacity: 0;
-        transition: opacity 0.15s ease;
+        transition: opacity 0.3s ease;
     }
 }
 
@@ -52,7 +52,7 @@
 
     &.beforeClose {
         background-color: transparent;
-        transition: background-color 0.15s ease;
+        transition: background-color 0.3s ease;
     }
 }
 

--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import ReactModal from 'react-modal';
 import styles from './Modal.css';
 
-const CLOSE_TRANSITION_DURATION = 250; // Must be 50ms higher than the actual CSS duration
+const CLOSE_TRANSITION_DURATION = 350; // Must be 50ms higher than the actual CSS duration
 
 const computeClassName = (className, classNameProp) => {
     if (classNameProp) {


### PR DESCRIPTION
This PR adjusts modal closing animation time. 

Closing animation is visible when users cancel their previous action (i.e., when they didn't mean that action and cancel it). However, when they click `confirm`, to confirm their previous action, the animation does not occur. The reason for this to happen is that the `modal` component is unmounted right away when they click `confirm`. 
This will be solved as soon as [this PR](https://github.com/ipfs-shipyard/discussify-styleguide/pull/5) is merged. Closing animation will happen in both scenarios.