### PR TITLE
fix: allow adding class names to fab logo

### DIFF
--- a/src/components/discussion-fab/DiscussionFab.js
+++ b/src/components/discussion-fab/DiscussionFab.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import BrandLogo from '../brand-logo';
 import styles from './DiscussionFab.css';
 
-const DicussionFab = ({ className, active, commentsCount, hasUnread, ...rest }) => {
+const DicussionFab = ({ className, logoClassName, active, commentsCount, hasUnread, ...rest }) => {
     const hasComments = commentsCount > 0;
     const finalClassName = classNames(
         styles.discussionFab,
@@ -12,12 +12,13 @@ const DicussionFab = ({ className, active, commentsCount, hasUnread, ...rest }) 
         hasComments && hasUnread && styles.hasUnread,
         className
     );
+    const logoFinalClassName = classNames(styles.logo, logoClassName);
 
     return (
         <button { ...rest } className={ finalClassName }>
             { hasComments ?
                 <span className={ styles.commentsCount }>{ commentsCount }</span> :
-                <BrandLogo variant="logomark" className={ styles.logo } /> }
+                <BrandLogo variant="logomark" className={ logoFinalClassName } /> }
         </button>
     );
 };
@@ -27,6 +28,7 @@ DicussionFab.propTypes = {
     commentsCount: PropTypes.number,
     hasUnread: PropTypes.bool,
     className: PropTypes.string,
+    logoClassName: PropTypes.string,
 };
 
 export default DicussionFab;

--- a/src/components/discussion-fab/README.md
+++ b/src/components/discussion-fab/README.md
@@ -19,5 +19,7 @@ import { DiscussionFab } from '@discussify/styleguide';
 | active | bool | false | Enables or disbles active state |
 | commentsCount | number | | Number of comments within the discussion |
 | hasUnread | bool | false | True if there's unread comments within the discussion |
+| className | string | | CSS classes to apply to the root element |
+| logoClassName | string | | CSS classes to apply to the brand logo |
 
 Any other properties supplied will be spread to the root element.


### PR DESCRIPTION
Created `logoClassName` prop in `DiscussionFab` component to enable supply of CSS classes to FAB's logo.